### PR TITLE
fix spelling error in default ckpt config path in inference.py

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     parser.add_argument("--in_wav", type=str, required=True, help="Path to input wav file")
     parser.add_argument("--out_wav", type=str, required=True, help="Path to output wav file")
     parser.add_argument("--ckpt", type=str, required=True, help="Path to model checkpoint file", default="model/pytorch_model.bin")
-    parser.add_argument("--config", type=str, help="Path to model config file", default="config/apollo.yaml")
+    parser.add_argument("--config", type=str, help="Path to model config file", default="configs/apollo.yaml")
     parser.add_argument("--chunk_size", type=int, help="chunk size value in seconds", default=10)
     parser.add_argument("--overlap", type=int, help="Overlap", default=2)
     args = parser.parse_args()


### PR DESCRIPTION
Hi, there is a spelling error in the default config path. Specifically, the 'config' directory does not exist. It should be 'configs'. I corrected the spelling.